### PR TITLE
Upgrade Dotty to 0.23.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "0.22.0-RC1" // dottyLatestNightlyBuild.get
+val dottyVersion = "0.23.0-RC1" // dottyLatestNightlyBuild.get
 
 lazy val root = project
   .in(file("."))

--- a/src/main/scala/dotty/xml/interpolator/internal/Expand.scala
+++ b/src/main/scala/dotty/xml/interpolator/internal/Expand.scala
@@ -49,7 +49,7 @@ object Expand {
   }
 
   private def expandAttributes(attributes: Seq[Attribute])(implicit ctx: XmlContext, qctx: QuoteContext): Expr[scala.xml.MetaData] = {
-    import qctx.tasty.{_, given}
+    import qctx.tasty._
     attributes.foldRight('{ _root_.scala.xml.Null }: Expr[scala.xml.MetaData])((attribute, rest) => {
       val value = attribute.value match {
           case Seq(v) => expandNode(v)
@@ -88,7 +88,7 @@ object Expand {
   }
 
   private def expandNamespaces(namespaces: Seq[Attribute])(implicit ctx: XmlContext, qctx: QuoteContext): Expr[scala.xml.NamespaceBinding] = {
-    import qctx.tasty.{_, given}
+    import qctx.tasty._
     namespaces.foldLeft(ctx.scope)((rest, namespace) => {
       val prefix = if (namespace.prefix.nonEmpty) Expr(namespace.key) else '{ null: String }
       val uri = (namespace.value.head: @unchecked) match {
@@ -99,25 +99,25 @@ object Expand {
     })
   }
 
-  private def expandText(text: Text)(given QuoteContext): Expr[scala.xml.Text] =
+  private def expandText(text: Text)(using QuoteContext): Expr[scala.xml.Text] =
     '{ new _root_.scala.xml.Text(${Expr(text.text)}) }
 
-  private def expandComment(comment: Comment)(given QuoteContext): Expr[scala.xml.Comment] =
+  private def expandComment(comment: Comment)(using QuoteContext): Expr[scala.xml.Comment] =
     '{ new _root_.scala.xml.Comment(${Expr(comment.text)}) }
 
   private def expandPlaceholder(placeholder: Placeholder)(implicit ctx: XmlContext, qctx: QuoteContext): Expr[Any] = {
     Expr.betaReduceGiven(ctx.args(placeholder.id))(ctx.scope)
   }
 
-  private def expandPCData(pcdata: PCData)(given QuoteContext): Expr[scala.xml.PCData] =
+  private def expandPCData(pcdata: PCData)(using QuoteContext): Expr[scala.xml.PCData] =
     '{ new _root_.scala.xml.PCData(${Expr(pcdata.data)}) }
 
-  private def expandProcInstr(instr: ProcInstr)(given QuoteContext): Expr[scala.xml.ProcInstr] =
+  private def expandProcInstr(instr: ProcInstr)(using QuoteContext): Expr[scala.xml.ProcInstr] =
     '{ new _root_.scala.xml.ProcInstr(${Expr(instr.target)}, ${Expr(instr.proctext)}) }
 
-  private def expandEntityRef(ref: EntityRef)(given QuoteContext): Expr[scala.xml.EntityRef] =
+  private def expandEntityRef(ref: EntityRef)(using QuoteContext): Expr[scala.xml.EntityRef] =
     '{ new _root_.scala.xml.EntityRef(${Expr(ref.name)}) }
 
-  private def expandUnparsed(unparsed: Unparsed)(given QuoteContext): Expr[scala.xml.Unparsed] =
+  private def expandUnparsed(unparsed: Unparsed)(using QuoteContext): Expr[scala.xml.Unparsed] =
     '{ new _root_.scala.xml.Unparsed(${Expr(unparsed.data)}) }
 }

--- a/src/main/scala/dotty/xml/interpolator/internal/Parse.scala
+++ b/src/main/scala/dotty/xml/interpolator/internal/Parse.scala
@@ -13,7 +13,7 @@ object Parse extends JavaTokenParsers with TokenTests {
 
   override val whiteSpace = "".r
 
-  def apply(input: String)(given reporter: Reporter): Seq[Tree.Node] = {
+  def apply(input: String)(using reporter: Reporter): Seq[Tree.Node] = {
     parseAll(XmlExpr, input) match {
       case Success(result, _) => result
       case failed : NoSuccess => reporter.error(failed.msg, failed.next.pos); Nil

--- a/src/main/scala/dotty/xml/interpolator/internal/TypeCheck.scala
+++ b/src/main/scala/dotty/xml/interpolator/internal/TypeCheck.scala
@@ -6,13 +6,13 @@ import scala.quoted._
 import dotty.xml.interpolator.internal.Tree._
 
 object TypeCheck {
-  def apply(nodes: Seq[Node])(given XmlContext, Reporter, QuoteContext): Seq[Node] = {
+  def apply(nodes: Seq[Node])(using XmlContext, Reporter, QuoteContext): Seq[Node] = {
     typecheck(nodes)
     nodes
   }
 
-  private def typecheck(nodes: Seq[Node])(given XmlContext, Reporter)(given qctx: QuoteContext): Unit = {
-    import qctx.tasty.{_, given}
+  private def typecheck(nodes: Seq[Node])(using XmlContext, Reporter)(using qctx: QuoteContext): Unit = {
+    import qctx.tasty._
     nodes.foreach {
       case elem : Elem =>
         elem.attributes.foreach(attribute =>

--- a/src/main/scala/dotty/xml/interpolator/internal/Validate.scala
+++ b/src/main/scala/dotty/xml/interpolator/internal/Validate.scala
@@ -6,13 +6,13 @@ import scala.language.implicitConversions
 import dotty.xml.interpolator.internal.Tree._
 
 object Validate {
-  def apply(nodes: Seq[Node])(given Reporter): Seq[Node] = {
+  def apply(nodes: Seq[Node])(using Reporter): Seq[Node] = {
     mismatchedElements(nodes)
     duplicateAttributes(nodes)
     nodes
   }
 
-  private def mismatchedElements(nodes: Seq[Node])(given reporter: Reporter): Unit = {
+  private def mismatchedElements(nodes: Seq[Node])(using reporter: Reporter): Unit = {
     nodes.foreach {
       case elem@Elem(name, _, _, Some(end)) =>
         if (name != end) reporter.error(s"closing tag `${name}` expected but `${end}` found", elem.pos)
@@ -21,7 +21,7 @@ object Validate {
     }
   }
 
-  private def duplicateAttributes(nodes: Seq[Node])(given reporter: Reporter): Unit = {
+  private def duplicateAttributes(nodes: Seq[Node])(using reporter: Reporter): Unit = {
     nodes.foreach {
       case Elem(_, attributes, children, _) =>
         attributes

--- a/src/main/scala/dotty/xml/interpolator/internal/XmlContext.scala
+++ b/src/main/scala/dotty/xml/interpolator/internal/XmlContext.scala
@@ -3,4 +3,4 @@ package internal
 
 import scala.quoted._
 
-class XmlContext(val args: Seq[Expr[(given Scope) => Any]], val scope: Expr[scala.xml.NamespaceBinding])
+class XmlContext(val args: Seq[Expr[Scope ?=> Any]], val scope: Expr[scala.xml.NamespaceBinding])

--- a/src/main/scala/dotty/xml/interpolator/package.scala
+++ b/src/main/scala/dotty/xml/interpolator/package.scala
@@ -5,5 +5,5 @@ import scala.quoted._
 type Scope = scala.xml.NamespaceBinding
 implicit val top: Scope = scala.xml.TopScope
 
-inline def (inline ctx: StringContext) xml (inline args: ((given Scope) => Any)*)(given scope: Scope) <: Any =
+inline def (inline ctx: StringContext) xml (inline args: (Scope ?=> Any)*)(using scope: Scope) <: Any =
   ${ dotty.xml.interpolator.internal.Macro.impl('ctx, 'args, 'scope) }

--- a/src/test/scala/dotty/xml/interpolator/ReporterTest.scala
+++ b/src/test/scala/dotty/xml/interpolator/ReporterTest.scala
@@ -5,7 +5,7 @@ import org.junit.Assert._
 
 class ReporterTest {
 
-  inline def (inline ctx: StringContext) xml (inline args: ((given Scope) => Any)*)(given Scope) <: Any =
+  inline def (inline ctx: StringContext) xml (inline args: (Scope ?=> Any)*)(using Scope) <: Any =
     ${ dotty.xml.interpolator.internal.Macro.implErrors('ctx, 'args, '{implicitly[Scope]}) }
 
   @Test def empty1(): Unit = {


### PR DESCRIPTION
I've done some quick fixes to make the project 0.23.0-RC1-compatible but am still getting errors.

<details><summary>Errors</summary>

```scala
sbt:dotty-xml-interpolator> test
[info] Compiling 12 Scala sources to /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/target/scala-0.23/classes ...
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:5:30: an identifier expected, but 'given' found
[error] import scala.quoted.autolift.given
[error]                              ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:6:8: ';' expected, but identifier found
[error] import scala.quoted.matching._
[error]        ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:5:29: ambiguous implicit arguments: both method ArrayOfCharIsLiftable in object Liftable and method ByteIsLiftable in object Liftable match type quoted.Liftable[T] of parameter x$1 of method autolift in package scala.quoted
[error] import scala.quoted.autolift.given
[error]                             ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:15:39: Type must be fully defined.
[error] Consider annotating the splice using a type ascription:
[error]   (${ExprSeq(parts)}: XYZ).
[error]       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
[error]                                       ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:15:56: Not found: ExprSeq
[error]       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
[error]                                                        ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:16:40: Found:    (parts : Any)
[error] Required: Seq[quoted.Expr[String]]
[error]         val (xmlStr, offsets) = encode(parts)
[error]                                        ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:17:55: Found:    (args : Any)
[error] Required: Seq[quoted.Expr[(dotty.xml.interpolator.Scope) ?=> Any]]
[error]         implicit val ctx: XmlContext = new XmlContext(args, scope)
[error]                                                       ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:22:62: Found:    (parts : Any)
[error] Required: Seq[quoted.Expr[String]]
[error]             val (part, offset) = Reporter.from(idx, offsets, parts)
[error]                                                              ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:38:39: Type must be fully defined.
[error] Consider annotating the splice using a type ascription:
[error]   (${ExprSeq(parts)}: XYZ).
[error]       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
[error]                                       ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:38:56: Not found: ExprSeq
[error]       case ('{ StringContext(${ExprSeq(parts)}: _*) }, ExprSeq(args)) =>
[error]                                                        ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:40:40: Found:    (parts : Any)
[error] Required: Seq[quoted.Expr[String]]
[error]         val (xmlStr, offsets) = encode(parts)
[error]                                        ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:41:55: Found:    (args : Any)
[error] Required: Seq[quoted.Expr[(dotty.xml.interpolator.Scope) ?=> Any]]
[error]         implicit val ctx: XmlContext = new XmlContext(args, scope)
[error]                                                       ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:46:62: Found:    (parts : Any)
[error] Required: Seq[quoted.Expr[String]]
[error]             val (part, offset) = Reporter.from(idx, offsets, parts)
[error]                                                              ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:47:49: value parts does not take parameters
[error]             val start = part.unseal.pos.start - parts(0).unseal.pos.start
[error]                                                 ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:48:53: Found:    (msg : String)
[error] Required: quoted.Expr[Any]
[error]             errors += '{ Tuple2(${start + offset}, $msg) }
[error]                                                     ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:53:35: Found:    Int
[error] Required: quoted.Expr[Any]
[error]             errors += '{ Tuple2(${pos.start}, $msg) }
[error]                                   ^
[error] /Users/kmetiuk/Projects/scala3/tools/dotty-release-scripts/ecosystem_projects/xml-interpolator/src/main/scala/dotty/xml/interpolator/internal/Macro.scala:53:48: Found:    (msg : String)
[error] Required: quoted.Expr[Any]
[error]             errors += '{ Tuple2(${pos.start}, $msg) }
[error]                                                ^
[error] 17 errors found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 10 s, completed 18 Mar 2020, 14:46:35
```
</details>

@nicolasstucki can I ask you to take it from here?