### PR TITLE
Update Scala to 3.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val dottyVersion = "3.1.1" // dottyLatestNightlyBuild.get
+val dottyVersion = "3.1.2" // dottyLatestNightlyBuild.get
 
 lazy val root = project
   .in(file("."))


### PR DESCRIPTION
PR submitted automatically by Scala 3 release tooling.